### PR TITLE
SSA as SSL

### DIFF
--- a/1-download.r
+++ b/1-download.r
@@ -3,11 +3,11 @@ library(plyr)
 library(XML)
 
 save_year <- function(year) {
-  url <- "http://www.ssa.gov/cgi-bin/popularnames.cgi"
+  url <- "https://www.ssa.gov/cgi-bin/popularnames.cgi"
   data <- postForm(url, style = "post", 
     "number" = "p", "top" = "1000", "year" = year) 
   writeLines(data, paste("original/", year, ".html", sep=""))
 }
 
-years <- 1880:2008
+years <- 1880:2015
 l_ply(years, save_year)

--- a/by-state/1-download.r
+++ b/by-state/1-download.r
@@ -2,12 +2,12 @@ library(RCurl)
 library(plyr)
 
 save_year <- function(state, year) {
-  url <- "http://www.ssa.gov/cgi-bin/namesbystate.cgi"
+  url <- "https://www.ssa.gov/cgi-bin/namesbystate.cgi"
   data <- postForm(url, style = "post", "year" = year, "state" = state) 
   writeLines(data, paste("original/", state, "-", year, ".html", sep=""))
 }
 
-years <- 1960:2008
+years <- 1960:2015
 states <- c("AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY")
 
 m_ply(expand.grid(state = states, year = years), save_year, 


### PR DESCRIPTION
SSA uses SSL now; `POST` requests to `http://` fail. This PR updates the URLs in the download scripts, and also updates the end year to 2015.

See also https://github.com/ericsoco/baby-name-scraper. Thanks for getting me started!
